### PR TITLE
Fix decoding for false-negative i8

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -55,7 +55,13 @@ pub fn write_i64<W: Write>(w: &mut W, v: i64) -> std::io::Result<()> {
 pub fn read_signed<R: Read + ?Sized>(r: &mut R) -> std::io::Result<i64> {
     let c = r.read_u8()?;
     let v = match c {
-        CODE_NEG_INT8 => r.read_i8()? as i64,
+        CODE_NEG_INT8 => {
+            let i = r.read_i8()? as i64;
+            if i >= 0 {
+                return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "Neg_int8"));
+            }
+            i
+        }
         CODE_INT16 => r.read_i16::<LittleEndian>()? as i64,
         CODE_INT32 => r.read_i32::<LittleEndian>()? as i64,
         CODE_INT64 => r.read_i64::<LittleEndian>()?,
@@ -73,4 +79,16 @@ pub fn read_nat0<R: Read + ?Sized>(r: &mut R) -> std::io::Result<u64> {
         c => c as u64,
     };
     Ok(v)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checks that incorrect input for negative byte is rejected.
+    #[test]
+    fn invalid_encoding() {
+        let mut encoded = &[CODE_NEG_INT8, 0][..];
+        assert!(read_signed(&mut encoded).is_err())
+    }
 }


### PR DESCRIPTION
This fix reports an error if `CODE_NEG_INT8` is followed by non-negative byte when decoding an integer.

Fixes: #1