### PR TITLE
Add Result read/write implementations

### DIFF
--- a/tests/derive_tests.rs
+++ b/tests/derive_tests.rs
@@ -227,3 +227,20 @@ fn breakfast_str() {
     let err = String::binprot_read(&mut data.as_slice());
     assert!(err.is_err())
 }
+
+#[derive(BinProtRead, BinProtWrite, Debug, PartialEq)]
+enum BinProtResult<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+#[test]
+fn result_same_as_derived() {
+    let result: Result<i64, String> = Err("test".to_string());
+    let mut data: Vec<u8> = Vec::new();
+    result.binprot_write(&mut data).unwrap();
+    let mut slice = data.as_slice();
+    let derived_result: BinProtResult<i64, String> =
+        BinProtResult::binprot_read(&mut slice).unwrap();
+    assert_eq!(derived_result, BinProtResult::Err("test".to_string()));
+}

--- a/tests/shape_tests.rs
+++ b/tests/shape_tests.rs
@@ -120,6 +120,7 @@ fn test_shapes() {
     assert_digest::<Vec<i64>>("4c138035aa69ec9dd8b7a7119090f84a");
     assert_digest::<()>("86ba5df747eec837f0b391dd49f33f9e");
     assert_digest::<Option<i64>>("33fd4ff7bde530bddf13dfa739207fae");
+    assert_digest::<Result<i64, String>>("d90ddb29b1dc8ae4416867c01634f2de");
     assert_eq!(format!("{:?}", TestVariant::binprot_shape()), "Variant([(\"Foo\", [])])");
     assert_digest::<TestVariant>("81253431711eb0c9d669d0cf1c5ffea7");
     assert_digest::<TestVariant2>("6b5a9ecfe97b786f98c8b9e502c3d6db");


### PR DESCRIPTION
I've checked this is compatible with `bin_io` on `Result.t` in OCaml.

The bin digests are different, but it seems like the bin digests for all types are different (but stable).